### PR TITLE
Fixed the bug: Valid Feed does not display events

### DIFF
--- a/widget/controllers/widget.feed.controller.js
+++ b/widget/controllers/widget.feed.controller.js
@@ -334,7 +334,7 @@
               CalenderFeedApi.getFeedEvents(WidgetFeed.data.content.feedUrl, eventFromDate, 0, true, 'ALL').then(successAll, errorAll);
           };
 
-          /*This method is used to load the from Datastore*/
+          /*This method is used to load the events from the selected month*/
           WidgetFeed.loadMore = function (refreshData) {
               Buildfire.spinner.show();
               if (WidgetFeed.busy) return;

--- a/widget/controllers/widget.feed.controller.js
+++ b/widget/controllers/widget.feed.controller.js
@@ -392,6 +392,7 @@
                       WidgetFeed.offset = 0;
                       WidgetFeed.busy = false;
                       WidgetFeed.eventClassToggle = true;
+                      WidgetFeed.getAllEvents();
                       WidgetFeed.loadMore(false);
                   }
                   $scope.$broadcast('refreshDatepickers');


### PR DESCRIPTION
file fixed:
widget/controllers/widget.feed.controller.js
After an update of the ICS file URL, after passing the validation of the URL, the WidgetFeed.events and WidgetFeed.eventsAll arrays are emptied, so we should call the WidgetFeed.getAllEvents function to populate those arrays with the data extracted from the new URL.
The new URL I used to do the test is https://www.kayaposoft.com/enrico/ics/v2.0?country=mex&fromDate=01-01-2018&toDate=31-12-2018&region=&holidayType=public_holiday&lang=es
--Additional fix:---
As far as I saw studying the code and debugging the plugin WidgetFeed.loadMore function is used to select events for a month, so I updated the description comment for this function, which said that the method was used to load the data from the datastore, but the OnUpdate() callback function of the datastore is the function beginning in the line 368, and the datastore actually contains the URL name, but not the data contained in the file referenced by the URL.